### PR TITLE
added memu.no to schema for semantic assocation with nav

### DIFF
--- a/src/assets/schema.json
+++ b/src/assets/schema.json
@@ -63,6 +63,7 @@
     "https://arbeidsplassen.nav.no",
     "http://navlab.no/",
     "https://www.detsombetyrnoe.no/",
+    "https://memu.no/",
     "https://www.facebook.com/navforeldrepenger",
     "https://www.facebook.com/DeterdinPensjon/",
     "https://www.facebook.com/navjobblyst",


### PR DESCRIPTION
Added memu.no to schema to add semantic association with other NAV-owned domains. 

See https://schema.org/sameAs