### PR TITLE
Mapper feilkoder fra api

### DIFF
--- a/server/server.ts
+++ b/server/server.ts
@@ -78,7 +78,7 @@ server.post(
         if (!response.ok) {
             const error = await response.text();
             console.log(`Feil i kall til tilbakemeldingsmottak-api: ${error}`);
-            return res.status(response.status).send(response.json);
+            return res.status(response.status).send(await response.json);
         }
 
         const responseData = await response.json();

--- a/server/server.ts
+++ b/server/server.ts
@@ -78,7 +78,7 @@ server.post(
         if (!response.ok) {
             const error = await response.text();
             console.log(`Feil i kall til tilbakemeldingsmottak-api: ${error}`);
-            return res.status(response.status).send({ error });
+            return res.status(response.status).send(response.json);
         }
 
         const responseData = await response.json();

--- a/server/server.ts
+++ b/server/server.ts
@@ -76,9 +76,9 @@ server.post(
         });
 
         if (!response.ok) {
-            const error = await response.text();
+            const error = await response.json();
             console.log(`Feil i kall til tilbakemeldingsmottak-api: ${error}`);
-            return res.status(response.status).send(await response.json);
+            return res.status(response.status).send(error);
         }
 
         const responseData = await response.json();

--- a/server/server.ts
+++ b/server/server.ts
@@ -77,7 +77,8 @@ server.post(
 
         if (!response.ok) {
             const error = await response.json();
-            console.log(`Feil i kall til tilbakemeldingsmottak-api: ${error}`);
+            const errorString = await response.text()
+            console.log(`Feil i kall til tilbakemeldingsmottak-api: ${errorString}`);
             return res.status(response.status).send(error);
         }
 

--- a/server/server.ts
+++ b/server/server.ts
@@ -77,8 +77,10 @@ server.post(
 
         if (!response.ok) {
             const error = await response.json();
-            const errorString = await response.text()
-            console.log(`Feil i kall til tilbakemeldingsmottak-api: ${errorString}`);
+            const errorString = await response.text();
+            console.log(
+                `Feil i kall til tilbakemeldingsmottak-api: ${errorString}`
+            );
             return res.status(response.status).send(error);
         }
 

--- a/src/language/en.ts
+++ b/src/language/en.ts
@@ -112,7 +112,9 @@ const en = {
     'validering.postadr.pakrevd': 'Postal address is required',
     'validering.gjeldersosialhjelp.pakrevd':
         'You must select whether the feedback applies to financial social assistance/social services',
-
+    'feilmelding.generell':
+        'Oops! A technical error occurred while submitting the form - please try again later.',
+    'feilmelding.orgnr': 'Organisation number was not found.',
     'felter.navn.tittel': 'Name',
     'felter.navn.tittel.valgfritt': 'Name (optional)',
     'felter.epost.tittel': 'Email',
@@ -125,8 +127,6 @@ const en = {
         'Error when using screen readers or other accessibility devices',
     'felter.melding.tittel': 'Your feedback',
     'felter.melding.beskrivelse': `Do not send sensitive personal information about yourself or others. Read more about personal information at <DatatilsynetLenke>Datatilsynet</DatatilsynetLenke>.`,
-    'felter.noegikkgalt':
-        'Oops! A technical error occurred while submitting the form - please try again later.',
     'felter.send': 'Send feedback',
     'felter.tilbake': 'Back',
     'felter.hvemroses.tittel': 'Who do you want to praise?',

--- a/src/language/nb.ts
+++ b/src/language/nb.ts
@@ -107,7 +107,9 @@ const nb = {
     'validering.postadr.pakrevd': 'Postadresse er nødvendig',
     'validering.gjeldersosialhjelp.pakrevd':
         'Du må velge om tilbakemeldingen gjelder økonomisk sosialhjelp / sosiale tjenester',
-
+    'feilmelding.generell':
+        'Oi! Det skjedde en teknisk feil ved innsending av skjemaet, prøv igjen senere.',
+    'feilmelding.orgnr': 'Kunne ikke finne organisasjonsnummer.',
     'felter.navn.tittel': 'Navn',
     'felter.navn.tittel.valgfritt': 'Navn (valgfritt)',
     'felter.epost.tittel': 'E-post',
@@ -119,8 +121,6 @@ const nb = {
         'Feil på siden ved bruk av skjermleser eller annet hjelpemiddel',
     'felter.melding.tittel': 'Din tilbakemelding',
     'felter.melding.beskrivelse': `Ikke send sensitive personopplysninger om deg selv eller andre. Les mer om personopplysninger hos <DatatilsynetLenke>Datatilsynet</DatatilsynetLenke>.`,
-    'felter.noegikkgalt':
-        'Oi! Det skjedde en teknisk feil ved innsending av skjemaet, prøv igjen senere.',
     'felter.send': 'Send tilbakemelding',
     'felter.tilbake': 'Tilbake',
     'felter.hvemroses.tittel': 'Hvem vil du gi ros til?',

--- a/src/language/nn.ts
+++ b/src/language/nn.ts
@@ -108,7 +108,9 @@ const nn = {
     'validering.postadr.pakrevd': 'Postadresse er nødvendig',
     'validering.gjeldersosialhjelp.pakrevd':
         'Du må velje om tilbakemeldinga gjeld økonomisk sosialhjelp / sosiale tenester',
-
+    'feilmelding.generell':
+        'Oi! Det skjedde ein teknisk feil ved sending av skjemaet, prøv igjen seinare.',
+    'feilmelding.orgnr': 'Kunne ikkje finne organisasjonsnummer.',
     'felter.navn.tittel': 'Namn',
     'felter.navn.tittel.valgfritt': 'Namn (valfritt)',
     'felter.epost.tittel': 'E-post',
@@ -120,8 +122,6 @@ const nn = {
         'Feil på sida ved bruk av skjermlesar eller anna hjelpemiddel',
     'felter.melding.tittel': 'Tilbakemeldinga di',
     'felter.melding.beskrivelse': `Ikkje send sensitive personopplysningar om deg sjølv eller andre. Les meir om personopplysningar hos <DatatilsynetLenke>Datatilsynet</DatatilsynetLenke>.`,
-    'felter.noegikkgalt':
-        'Oi! Det skjedde ein teknisk feil ved sending av skjemaet, prøv igjen seinare.',
     'felter.send': 'Send tilbakemelding',
     'felter.tilbake': 'Tilbake',
     'felter.hvemroses.tittel': 'Kven vil du gje ros til?',

--- a/src/pages/tilbakemeldinger/feil-og-mangler/FeilOgMangler.tsx
+++ b/src/pages/tilbakemeldinger/feil-og-mangler/FeilOgMangler.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import VeilederIcon from 'assets/icons/Veileder.svg';
 import InputMelding from 'components/input-fields/InputMelding';
 import { postFeilOgMangler } from 'clients/apiClient';
-import { HTTPError } from 'types/errors';
+import { ErrorResponse } from 'types/errors';
 import Header from 'components/header/Header';
 import { paths, vars } from 'Config';
 import Box from 'components/box/Box';
@@ -19,6 +19,7 @@ import {
     FormProvider,
     useForm,
 } from 'react-hook-form';
+import { resolveErrorCode } from '../../../utils/errorCodes';
 
 type FEILTYPE = 'TEKNISK_FEIL' | 'FEIL_INFO' | 'UNIVERSELL_UTFORMING';
 
@@ -51,8 +52,8 @@ const FOM = () => {
 
     const [loading, settLoading] = useState(false);
     const [success, settSuccess] = useState(false);
-    const [error, settError] = useState<string | undefined>();
-    const { formatMessage } = useIntl();
+    const [error, settError] = useState<ErrorResponse>();
+    const {formatMessage} = useIntl();
 
     const send = (values: FieldValues) => {
         const { onskerKontakt, feiltype, melding, epost } = values;
@@ -72,8 +73,8 @@ const FOM = () => {
                 settSuccess(true);
                 triggerHotjar('feilogmangler');
             })
-            .catch((error: HTTPError) => {
-                settError(`${error.code} - ${error.text}`);
+            .catch((error: ErrorResponse) => {
+                settError(error);
             })
             .then(() => {
                 settLoading(false);
@@ -178,7 +179,9 @@ const FOM = () => {
                                         className={'felter__melding-advarsel'}
                                     >
                                         <FormattedMessage
-                                            id={'felter.noegikkgalt'}
+                                            id={resolveErrorCode(
+                                                error.errorCode
+                                            )}
                                         />
                                     </Alert>
                                 )}

--- a/src/pages/tilbakemeldinger/feil-og-mangler/FeilOgMangler.tsx
+++ b/src/pages/tilbakemeldinger/feil-og-mangler/FeilOgMangler.tsx
@@ -53,7 +53,7 @@ const FOM = () => {
     const [loading, settLoading] = useState(false);
     const [success, settSuccess] = useState(false);
     const [error, settError] = useState<ErrorResponse>();
-    const {formatMessage} = useIntl();
+    const { formatMessage } = useIntl();
 
     const send = (values: FieldValues) => {
         const { onskerKontakt, feiltype, melding, epost } = values;

--- a/src/pages/tilbakemeldinger/ros-til-nav/Ros.tsx
+++ b/src/pages/tilbakemeldinger/ros-til-nav/Ros.tsx
@@ -50,7 +50,7 @@ const Ros = () => {
     const [loading, settLoading] = useState(false);
     const [success, settSuccess] = useState(false);
     const [error, settError] = useState<ErrorResponse>();
-    const {formatMessage} = useIntl();
+    const { formatMessage } = useIntl();
 
     const send = (values: FieldValues) => {
         const { melding, hvemRoses, navKontor } = values;

--- a/src/pages/tilbakemeldinger/ros-til-nav/Ros.tsx
+++ b/src/pages/tilbakemeldinger/ros-til-nav/Ros.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import VeilederIcon from 'assets/icons/Veileder.svg';
 import InputMelding from 'components/input-fields/InputMelding';
 import { postRosTilNav } from 'clients/apiClient';
-import { HTTPError } from 'types/errors';
+import { ErrorResponse } from 'types/errors';
 import Header from 'components/header/Header';
 import { paths, vars } from 'Config';
 import Box from 'components/box/Box';
@@ -14,6 +14,7 @@ import { MetaTags } from '../../../components/metatags/MetaTags';
 import { Alert, Button, GuidePanel, Radio, RadioGroup } from '@navikt/ds-react';
 import { PersonvernInfo } from 'components/personvernInfo/PersonvernInfo';
 import { Controller, FieldValues, useForm } from 'react-hook-form';
+import { resolveErrorCode } from '../../../utils/errorCodes';
 
 type HVEM_ROSES = 'NAV_KONTAKTSENTER' | 'NAV_DIGITALE_TJENESTER' | 'NAV_KONTOR';
 
@@ -48,8 +49,8 @@ const Ros = () => {
 
     const [loading, settLoading] = useState(false);
     const [success, settSuccess] = useState(false);
-    const [error, settError] = useState<string | undefined>();
-    const { formatMessage } = useIntl();
+    const [error, settError] = useState<ErrorResponse>();
+    const {formatMessage} = useIntl();
 
     const send = (values: FieldValues) => {
         const { melding, hvemRoses, navKontor } = values;
@@ -68,8 +69,8 @@ const Ros = () => {
                 settSuccess(true);
                 triggerHotjar('rosnav');
             })
-            .catch((error: HTTPError) => {
-                settError(`${error.code} - ${error.text}`);
+            .catch((error: ErrorResponse) => {
+                settError(error);
             })
             .then(() => {
                 settLoading(false);
@@ -194,7 +195,7 @@ const Ros = () => {
                                     className={'felter__melding-advarsel'}
                                 >
                                     <FormattedMessage
-                                        id={'felter.noegikkgalt'}
+                                        id={resolveErrorCode(error.errorCode)}
                                     />
                                 </Alert>
                             )}

--- a/src/pages/tilbakemeldinger/service-klage/ServiceKlage.tsx
+++ b/src/pages/tilbakemeldinger/service-klage/ServiceKlage.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import VeilederIcon from 'assets/icons/Veileder.svg';
 import { useStore } from 'providers/Provider';
 import { postServiceKlage } from 'clients/apiClient';
-import { HTTPError } from 'types/errors';
+import { ErrorResponse } from 'types/errors';
 import InputMelding from 'components/input-fields/InputMelding';
 import {
     KLAGE_TYPE,
@@ -41,6 +41,7 @@ import {
     useForm,
 } from 'react-hook-form';
 import { PersonvernInfo } from 'components/personvernInfo/PersonvernInfo';
+import { resolveErrorCode } from '../../../utils/errorCodes';
 
 export interface ServiceklageFormFields {
     klagetekst: string;
@@ -87,7 +88,7 @@ const ServiceKlage = () => {
     const [{ auth, fodselsnr }] = useStore();
     const [loading, settLoading] = useState(false);
     const [success, settSuccess] = useState(false);
-    const [error, settError] = useState<string | undefined>();
+    const [error, settError] = useState<ErrorResponse>();
     const [loginClosed, setLoginClosed] = useState(false);
 
     const { formatMessage } = useIntl();
@@ -170,8 +171,8 @@ const ServiceKlage = () => {
                 settSuccess(true);
                 triggerHotjar('serviceklage');
             })
-            .catch((error: HTTPError) => {
-                settError(`${error.code} - ${error.text}`);
+            .catch((error: ErrorResponse) => {
+                settError(error);
             })
             .then(() => {
                 settLoading(false);
@@ -381,7 +382,9 @@ const ServiceKlage = () => {
                                         className={'felter__melding-advarsel'}
                                     >
                                         <FormattedMessage
-                                            id={'felter.noegikkgalt'}
+                                            id={resolveErrorCode(
+                                                error.errorCode
+                                            )}
                                         />
                                     </Alert>
                                 )}

--- a/src/types/errors.ts
+++ b/src/types/errors.ts
@@ -6,6 +6,10 @@ export interface BadRequest {
     path: string;
 }
 
+export interface ErrorResponse {
+    errorCode: string;
+}
+
 export interface HTTPError {
     code: number;
     text: string;

--- a/src/utils/errorCodes.ts
+++ b/src/utils/errorCodes.ts
@@ -1,0 +1,8 @@
+export const resolveErrorCode = (errorCode: string): string => {
+    switch (errorCode) {
+        case 'EREG_NOT_FOUND':
+            return 'feilmelding.orgnr';
+        default:
+            return 'feilmelding.generell.';
+    }
+};

--- a/src/utils/errorCodes.ts
+++ b/src/utils/errorCodes.ts
@@ -3,6 +3,6 @@ export const resolveErrorCode = (errorCode: string): string => {
         case 'EREG_NOT_FOUND':
             return 'feilmelding.orgnr';
         default:
-            return 'feilmelding.generell.';
+            return 'feilmelding.generell';
     }
 };


### PR DESCRIPTION
## Oppsummering av hva som er gjort

-   Mapper feilkoder fra tilbakemeldingsmottak-api til feilmeldinger på ulike språk (foreløpig kun to, men kan bli aktuelt med flere senere)

## Testing

Tester i dev
