### PR TITLE
Fjerner Modal.setAppElement() fra App, kjøres fra ServiceKlage

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,16 +19,11 @@ import ScrollToTop from './components/scroll-to-top/ScrollToTop';
 import { paths } from './Config';
 import { defaultLocale, localePath, validLocales } from './utils/locale';
 import { DecoratorWidgets } from './components/decorator-widgets/DecoratorWidgets';
-import { Modal } from '@navikt/ds-react';
 import '@navikt/ds-css';
 import { HelmetProvider } from 'react-helmet-async';
 
 const App = () => {
     const [{ auth }, dispatch] = useStore();
-
-    useEffect(() => {
-        Modal.setAppElement?.('#app');
-    }, []);
 
     useEffect(() => {
         if (!auth.authenticated) {


### PR DESCRIPTION
## Oppsummering av hva som er gjort
Dobbelt kall på Modal.setAppElement() skaper trøbbel. Tar vekk den på App-nivå.

## Testing
Har testet selv i dev