### PR TITLE
Fjernet visning av enhetsnummer i nedtrekksliste

### DIFF
--- a/src/components/input-fields/SelectEnhet.tsx
+++ b/src/components/input-fields/SelectEnhet.tsx
@@ -92,7 +92,7 @@ const SelectEnhet = (props: Props, ref: ForwardedRef<HTMLInputElement>) => {
                         .sort((a, b) => (a.navn < b.navn ? -1 : 1))
                         .map((enhet) => ({
                             value: enhet.enhetNr,
-                            label: `${enhet.navn} - ${enhet.enhetNr}`,
+                            label: `${enhet.navn}`,
                         }))}
                 />
             ) : (


### PR DESCRIPTION
## Oppsummering av hva som er gjort

Å vise enhetsnumrene har ingen relevanse for brukeren.
Fjernet derfor visning av enhetsnummer i nedtrekksliste (label).

Se for eksempel NAV-kontor --> NAV-enhet her:`
https://www.nav.no/person/kontakt-oss/nb/tilbakemeldinger/ros-til-nav

## Testing

Har testet selv i dev / lokalt

