### PR TITLE
Fjernet KO fra enhetslista

### DIFF
--- a/src/components/input-fields/SelectEnhet.tsx
+++ b/src/components/input-fields/SelectEnhet.tsx
@@ -44,7 +44,6 @@ const SelectEnhet = (props: Props, ref: ForwardedRef<HTMLInputElement>) => {
         'HMS',
         'INTRO',
         'KLAGE',
-        'KO',
         'KONTROLL',
         'LOKAL',
         'OKONOMI',


### PR DESCRIPTION
## Oppsummering av hva som er gjort

-   Fjernet KO fra nedtrekksliste. Eksempel på KO-enhet: Kontinentalsokkelen, NAV Dagpenger INN og NAV Partsinnsyn. 

Tilbakemelding fra Tom Guttormsen om at de har "aldri mottatt ros" for noen av enhetene i KO. Ole Jonas Nybø går for å fjerne disse enhetene.

## Testing

Har testet selv i dev
