### PR TITLE
Fikse dobbel tekstboks

### DIFF
--- a/common/language/en.ts
+++ b/common/language/en.ts
@@ -138,6 +138,7 @@ const en: ITranslation = {
     'felter.klagetyper.digitaletjenester': 'Navs digital services',
     'felter.klagetyper.brev': 'Letter',
     'felter.klagetyper.annet': 'Other',
+    'felter.klagetyper.annenKategori': 'Other category',
     'felter.hvemfra': 'Who are you writing on behalf of?',
     'felter.hvemfra.megselv': 'Myself as a private individual',
     'felter.hvemfra.enannen': 'On behalf of another private individual',

--- a/common/language/nb.ts
+++ b/common/language/nb.ts
@@ -131,6 +131,7 @@ const nb: ITranslation = {
     'felter.klagetyper.digitaletjenester': 'Navs digitale tjenester',
     'felter.klagetyper.brev': 'Brev',
     'felter.klagetyper.annet': 'Annet',
+    'felter.klagetyper.annenKategori': 'Annen kategori',
     'felter.hvemfra': 'Hvem skriver du på vegne av?',
     'felter.hvemfra.megselv': 'Meg selv som privatperson',
     'felter.hvemfra.enannen': 'På vegne av en annen privatperson',

--- a/common/language/nn.ts
+++ b/common/language/nn.ts
@@ -132,6 +132,7 @@ const nn: ITranslation = {
     'felter.klagetyper.digitaletjenester': 'Nav sine digitale tenester',
     'felter.klagetyper.brev': 'Brev',
     'felter.klagetyper.annet': 'Anna',
+    'felter.klagetyper.annenKategori': 'Anna kategori',
     'felter.hvemfra': 'Kven skriv du på vegne av?',
     'felter.hvemfra.megselv': 'Meg sjølv som privatperson',
     'felter.hvemfra.enannen': 'På vegne av ein annan privatperson',

--- a/src/App.module.scss
+++ b/src/App.module.scss
@@ -23,6 +23,10 @@
     }
 }
 
+.indent {
+    padding-left: 2rem;
+}
+
 .inputSmall {
     width: 12rem;
 }

--- a/src/pages/tilbakemeldinger/service-klage/ServiceKlageTypeUtdypning.tsx
+++ b/src/pages/tilbakemeldinger/service-klage/ServiceKlageTypeUtdypning.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useFormContext } from 'react-hook-form';
 import { ServiceklageFormFields } from './ServiceKlage';
-import { Textarea } from '@navikt/ds-react';
+import { TextField } from '@navikt/ds-react';
 import { useIntl } from 'react-intl';
 import appStyle from 'src/App.module.scss';
 import { vars } from 'src/Config';
@@ -22,23 +22,18 @@ const ServiceKlageTypeUtdypning = () => {
     }, [isSubmitted, trigger]);
 
     return (
-        <Textarea
+        <TextField
             {...register('klagetypeUtdypning', {
                 required: formatMessage({
                     id: 'validering.klagetype.utdypning.pakrevd',
                 }),
-                maxLength: {
-                    value: vars.maksLengdeMeldingServiceKlage,
-                    message: formatMessage({
-                        id: 'validering.melding.tegn',
-                    }),
-                },
             })}
             label={formatMessage({
-                id: 'felter.melding.tittel',
+                id: 'felter.klagetyper.annenKategori',
             })}
-            className={appStyle.inputMedium}
+            className={`${appStyle.inputMedium} ${appStyle.indent}`}
             value={watch().klagetypeUtdypning}
+            hideLabel
             error={errors?.klagetypeUtdypning?.message}
             maxLength={vars.maksLengdeMeldingServiceKlage}
             autoComplete="off"


### PR DESCRIPTION
## Oppsummering av hva som er gjort

* Oppdatert label med egen tekst (nb,nn,en)
* Byttet ut TextArea med TextField og skjult label.


## Testing

Har testet selv lokalt, med følgende sti `http://localhost:9001/person/kontakt-oss/nb/tilbakemeldinger/serviceklage`

## Dette trenger jeg å få et ekstra blikk på

Er det smartere måter å håndtere to klasser på samme element?